### PR TITLE
fix: add docs url/baseurl for GitHub Pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,7 +35,7 @@ kramdown:
   input: GFM
   syntax_highlighter: rouge
   
-# GitHub Pages設定
+# リポジトリ情報
 repository: 
   github: "https://github.com/itdojp/IT-infra-troubleshooting-book"
 


### PR DESCRIPTION
GitHub Pages（project site）で `relative_url` が正しく `baseurl` を付与できるよう、`docs/_config.yml` に `url` / `baseurl` を追加しました。

併せて、`plugins` の配列途中に紛れ込んでいた「除外ファイル」コメント位置を整理し、設定の可読性を改善しています。

- 期待値: `https://itdojp.github.io/IT-infra-troubleshooting-book/` 配下でCSS/JS/リンクが正しく解決される
