### PR TITLE
Stage3: 第3章 ラベル行の表記統一

### DIFF
--- a/docs/src/chapter-chapter03/index.md
+++ b/docs/src/chapter-chapter03/index.md
@@ -235,29 +235,29 @@ Webサーバーログの分析により、アクセスログとエラーログ�
 
 **基本接続性診断ツール**では、ネットワークの基本的な接続性と到達性を確認します。
 
-pingコマンドの高度な活用：
+pingコマンドの高度な活用
 - `ping -i 0.1 target`: 高頻度テスト（0.1秒間隔）
 - `ping -s 1472 target`: MTU サイズの確認
 - `ping -f target`: フラッド ping テスト（要注意）
 
-tracerouteの詳細分析：
+tracerouteの詳細分析
 - `traceroute -n target`: DNS 解決無効化
 - `traceroute -I target`: ICMP パケット使用
 - `mtr target`: 継続的経路監視
 
-DNS診断ツール：
+DNS診断ツール
 - `dig +trace domain`: 完全解決過程の追跡
 - `dig @server domain`: 特定DNSサーバーでのクエリ
 - `dig -x ipaddress`: 逆引きクエリ
 
 **詳細プロトコル分析ツール**では、ネットワークプロトコルレベルでの問題分析を行います。
 
-tcpdumpによるパケットキャプチャ：
+tcpdumpによるパケットキャプチャ
 - `tcpdump -i any host 192.168.1.1`: 特定ホスト監視
 - `tcpdump port 80 -w capture.pcap`: HTTP トラフィック保存
 - `tcpdump -n 'tcp[tcpflags] & tcp-syn != 0'`: SYN パケットのみ
 
-iperfによる帯域幅測定：
+iperfによる帯域幅測定
 - `iperf3 -c server -t 60`: 60秒間の帯域幅テスト
 - `iperf3 -c server -P 4`: 4並列接続テスト
 - `iperf3 -c server -R`: 逆方向測定
@@ -268,36 +268,36 @@ iperfによる帯域幅測定：
 
 **プロセス・リソース監視ツール**では、システムの動作状況とリソース使用状況を詳細に分析します。
 
-topコマンドの活用：
+topコマンドの活用
 - `top -p PID`: 特定プロセスの監視
 - `top -H`: スレッド表示
 - `top -c`: コマンドライン表示
 
-psコマンドの詳細分析：
+psコマンドの詳細分析
 - `ps aux --sort=-%cpu`: CPU使用率順
 - `ps -eLf`: 軽量プロセス（スレッド）表示
 - `ps -o pid,ppid,cmd,%cpu,%mem`: カスタム出力
 
 **ファイルシステム・I/O診断ツール**では、ストレージとファイルシステムの性能を分析します。
 
-iostatによるI/O統計：
+iostatによるI/O統計
 - `iostat -x 1`: 詳細I/O統計の継続監視
 - `iostat -c`: CPU統計も含める
 - `iostat -d`: デバイス統計のみ
 
-lsofによるファイル使用状況：
+lsofによるファイル使用状況
 - `lsof +D /path`: 特定ディレクトリ使用状況
 - `lsof -i :port`: 特定ポート使用状況
 - `lsof -p PID`: 特定プロセスのファイル使用
 
 **システム統計・性能分析ツール**では、システム全体の性能を統合的に分析します。
 
-vmstatによる統合監視：
+vmstatによる統合監視
 - `vmstat 1`: 1秒間隔での継続監視
 - `vmstat -d`: ディスク統計
 - `vmstat -s`: システム統計サマリー
 
-sarによるシステム活動記録：
+sarによるシステム活動記録
 - `sar -u`: CPU使用率履歴
 - `sar -r`: メモリ使用率履歴
 - `sar -d`: ディスク活動履歴
@@ -308,24 +308,24 @@ sarによるシステム活動記録：
 
 **システムコール・カーネルレベル分析**では、アプリケーションとOSの境界での動作を詳細に分析します。
 
-straceによるシステムコール追跡：
+straceによるシステムコール追跡
 - `strace -p PID`: 実行中プロセスの追跡
 - `strace -e trace=open,read,write cmd`: 特定システムコール追跡
 - `strace -c cmd`: システムコール統計
 
-perfによる性能プロファイリング：
+perfによる性能プロファイリング
 - `perf top`: リアルタイム性能監視
 - `perf record -g cmd`: 詳細性能記録
 - `perf report`: プロファイル結果分析
 
 **分散システム・マイクロサービス分析**では、複数のサービス間での問題を分析します。
 
-分散トレーシングツール：
+分散トレーシングツール
 - Jaeger: OpenTracing準拠の分散トレーシング
 - Zipkin: Twitter発の分散トレーシング
 - AWS X-Ray: AWS環境での分散トレーシング
 
-ログ集約・分析ツール：
+ログ集約・分析ツール
 - ELK Stack: Elasticsearch + Logstash + Kibana
 - Fluentd: ログ収集・転送
 - Grafana: メトリクス可視化


### PR DESCRIPTION
Stage3（表現・スタイル）として、第3章のラベル行の表記を整形しました。

- 行末が「：」で終わるラベル行（ツール名の列挙見出し）の末尾 `：` を削除し、見出し/ラベルとしての表記に統一

対象: `docs/src/chapter-chapter03/index.md`

関連: it-engineer-knowledge-architecture Issue #45
