### PR TITLE
netplan 見出し注記のUbuntuバージョン表記を一般化

### DIFF
--- a/docs/appendices/c.md
+++ b/docs/appendices/c.md
@@ -60,7 +60,9 @@ GATEWAY=192.168.1.1
 
 ### Ubuntu/Debian ネットワーク設定
 
-#### /etc/netplan/00-installer-config.yaml (Ubuntu / netplan)
+#### /etc/netplan/*.yaml の例 (Ubuntu / netplan)
+
+※ 実際のファイル名はインストール形態や環境により異なる場合があります（例: `00-installer-config.yaml` / `50-cloud-init.yaml`）。
 ```yaml
 network:
   version: 2

--- a/manuscript/appendices/c.md
+++ b/manuscript/appendices/c.md
@@ -60,7 +60,9 @@ GATEWAY=192.168.1.1
 
 ### Ubuntu/Debian ネットワーク設定
 
-#### /etc/netplan/00-installer-config.yaml (Ubuntu / netplan)
+#### /etc/netplan/*.yaml の例 (Ubuntu / netplan)
+
+※ 実際のファイル名はインストール形態や環境により異なる場合があります（例: `00-installer-config.yaml` / `50-cloud-init.yaml`）。
 ```yaml
 network:
   version: 2


### PR DESCRIPTION
`/etc/netplan/00-installer-config.yaml` の見出し注記から、EOL となったバージョン（Ubuntu 18.04）への依存を避けるため、表記を「Ubuntu / netplan」に一般化しました。

反映: `docs/appendices/c.md`, `manuscript/appendices/c.md`
