### PR TITLE
ci: actions/setup-node を v6 に更新（workflow）

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -24,7 +24,7 @@ jobs:
           path: book-formatter
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm


### PR DESCRIPTION
## 概要
- `.github/workflows`（および必要なテンプレート/ガイド）内の `actions/setup-node@v4` を `@v6` に更新
- 参照バージョンを統一し、旧メジャー参照の残存を解消

## 変更点
- `actions/setup-node@v4` -> `actions/setup-node@v6`

Closes #102