### PR TITLE
fix(nav): prev/next が prefix パスで崩れる問題を修正

### DIFF
--- a/docs/_includes/page-navigation.html
+++ b/docs/_includes/page-navigation.html
@@ -50,18 +50,12 @@ level of such grouping so only leaf items (having `path`/`url`) participate.
         {%- assign _flat = "" | split: "|" -%}
         {%- for _grp in _items -%}
           {%- if _grp.items -%}
-            {%- assign _sub_items = _grp.items | where_exp: "it", "it.path or it.url" -%}
-            {%- if _sub_items and _sub_items.size > 0 -%}
-              {%- assign _flat = _flat | concat: _sub_items -%}
-            {%- endif -%}
+            {%- assign _flat = _flat | concat: _grp.items -%}
           {%- endif -%}
         {%- endfor -%}
         {%- assign seq = seq | concat: _flat -%}
       {%- else -%}
-        {%- assign _items_f = _items | where_exp: "it", "it.path or it.url" -%}
-        {%- if _items_f and _items_f.size > 0 -%}
-          {%- assign seq = seq | concat: _items_f -%}
-        {%- endif -%}
+        {%- assign seq = seq | concat: _items -%}
       {%- endif -%}
     {%- endif -%}
   {%- endfor -%}


### PR DESCRIPTION
ISSUE: itdojp/it-engineer-knowledge-architecture#110

- navigation に prefix/index（例: "/", "/chapters/" 等）が含まれる場合に、current page 判定が先勝ちになり prev/next が崩れる問題を修正しました。
- 現在ページの解決を「最長一致」に変更し、chapters が "part/items" 形式でネストしている場合もフラット化して prev/next の対象に含めます。

確認観点（デプロイ後）
- 章ページの「前へ/次へ」が期待順で遷移すること（先頭/中間/末尾）
