### PR TITLE
Drawer（TOC）: 現在位置を自動スクロール

### DIFF
--- a/docs/_layouts/book.html
+++ b/docs/_layouts/book.html
@@ -208,7 +208,7 @@
         });
     </script>
 
-        <script>
+            <script>
         // Auto-scroll active TOC into view when opening the drawer.
         (function() {
             function initTocAutoScroll() {
@@ -230,7 +230,9 @@
                         if (typeof window.matchMedia === 'function') {
                             return window.matchMedia('(max-width: 1024px)').matches;
                         }
-                    } catch (_) {}
+                    } catch (_) {
+                        // Ignore matchMedia failures and fall back to window.innerWidth.
+                    }
                     return typeof window.innerWidth === 'number' ? window.innerWidth <= 1024 : true;
                 }
 
@@ -281,7 +283,9 @@
                                     if (!isNaN(pb)) marginBottom = pb;
                                 }
                             }
-                        } catch (_) {}
+                        } catch (_) {
+                            // Ignore style parsing issues; keep fallback margins.
+                        }
 
                         var top = sidebarRect.top + marginTop;
                         var bottom = sidebarRect.bottom - marginBottom;
@@ -296,7 +300,9 @@
                                 active.scrollIntoView();
                             }
                         }
-                    } catch (_) {}
+                    } catch (_) {
+                        // Best-effort UX: ignore measurement errors.
+                    }
                 }
 
                 function scheduleEnsure() {
@@ -323,6 +329,7 @@
             }
         })();
     </script>
+
 
 
 </body>


### PR DESCRIPTION
Refs:
- it-engineer-knowledge-architecture Issue #122: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/122
- book-formatter PR #85（仕様/実装元）: https://github.com/itdojp/book-formatter/pull/85

## 変更内容
- モバイルで Drawer（TOC）を開いた直後に、現在位置の TOC（`a.toc-link.active`）が可視領域外の場合は `scrollIntoView` で中央付近に移動します。
- 既に可視領域内ならスクロールしません。

## 目的
- Drawer を開いた直後に「現在位置」が見えず手動スクロールが必要になるケースを解消します。
