### PR TITLE
[codex] Align troubleshooting docs version metadata

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 title: "ITインフラトラブルシューティング大全"
 description: "問題解決の思考法から各レイヤーの具体策まで〜システム障害に立ち向かう実践的ガイド〜"
 author: "ITDO Inc.（株式会社アイティードゥ）"
-version: "1.0.0"
+version: "1.0.1"
 lang: "ja"
 
 # GitHub Pages設定

--- a/docs/book-config.json
+++ b/docs/book-config.json
@@ -2,7 +2,7 @@
   "title": "ITインフラトラブルシューティング大全",
   "description": "問題解決の思考法から各レイヤーの具体策まで〜システム障害に立ち向かう実践的ガイド〜",
   "author": "ITDO Inc.（株式会社アイティードゥ）",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "structure": {
     "chapters": [
       {


### PR DESCRIPTION
## 概要

- 公開対象の `docs/_config.yml` と `docs/book-config.json` の version を、既に `book-config.json` と `docs/index.md` で使われている現行書籍バージョン `1.0.1` に揃えました。
- 本文、章構成、生成ツールの package/shared component version は変更していません。

Refs: itdojp/it-engineer-knowledge-architecture#152

## 背景 / 判断

- #152 quality sprint の次対象として、本リポジトリの open Issue / open PR がないことを確認しました。
- 現行 Pages / Book QA は `docs/` を対象にしているため、公開対象 metadata の不整合に限定して小粒対応しました。
- `output/` と `manuscript/` は既存PRで legacy/旧生成物として扱われており、今回の公開対象スライスからは除外しています。

## QA

- [x] `git diff --check`
- [x] `npm run lint`
- [x] `npm test`（33 tests）
- [x] `npm run check-links`
- [x] published docs version consistency assertion（`book-config.json`, `docs/_config.yml`, `docs/book-config.json`, `docs/index.md`）
- [x] `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/bundle-IT-infra-troubleshooting-book bundle install`（`docs/`）
- [x] `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/bundle-IT-infra-troubleshooting-book npm run build`
- [x] built-site smoke（top / appendix B / chapter06 markers）
- [x] Book QA equivalent with `itdojp/book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4`
  - Unicode（fail-on warn）
  - textlint / PRH（fail-on error）
  - internal links / anchors
  - layout risk（fail-on error）
  - markdown structure（fail-on error）

## Review Completion Gate

- [x] GitHub Copilot review を依頼した
- [x] review 本文・inline comment・suggestion を全件確認した
- [x] 修正が必要な指摘は対応し、不要な指摘は理由を返信した（Copilot generated 0 comments）
- [x] 未解決 review thread が 0 件であることを確認した（`pr-review-completeness`: `status=ok`, `unresolved_threads=0`）

## Pages確認

- 確認URL: https://itdojp.github.io/IT-infra-troubleshooting-book/
- [x] merge 後に main CI / Pages 反映を確認した
- [x] `/`, `/appendices/b/`, `/chapters/chapter06/` の HTTP 200 と主要マーカーを確認した
- [x] `/book-config.json` が `version=1.0.1` を返すことを確認した
