### PR TITLE
[codex] Add troubleshooting metadata QA gate

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -33,6 +33,9 @@ jobs:
           cache: npm
           cache-dependency-path: book-formatter/package-lock.json
 
+      - name: Metadata consistency check
+        run: npm run check:metadata
+
       - name: Install dependencies (book-formatter)
         working-directory: book-formatter
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@
 - リポジトリ内: `docs/index.md`
 - GitHub Pages を有効化している場合: `https://itdojp.github.io/IT-infra-troubleshooting-book/`
 
+## 品質確認
+
+公開メタデータとナビゲーションの整合性を確認する場合は、次のコマンドを実行します。
+
+```bash
+npm run check:metadata
+npm test
+```
+
+`check:metadata` は `book-config.json`、`docs/book-config.json`、`docs/_config.yml`、`docs/index.md`、`docs/_data/navigation.yml`、`package.json`、`package-lock.json` の公開情報を照合し、章・付録の経路と必須アセットの欠落を検出します。
+
 ## フィードバック
 
 - Issue: `https://github.com/itdojp/IT-infra-troubleshooting-book/issues`

--- a/book-config.json
+++ b/book-config.json
@@ -14,44 +14,76 @@
       {
         "id": "chapter01",
         "title": "第1章：トラブルシューティングの基本と心構え",
-        "description": "システム障害の本質的理解と効果的な問題解決の基盤構築"
+        "description": "システム障害の本質的理解と効果的な問題解決の基盤構築",
+        "path": "/chapters/chapter01/"
       },
       {
         "id": "chapter02",
         "title": "第2章：問題の特定と情報収集",
-        "description": "効果的な情報収集手法と状況把握技術の習得"
+        "description": "効果的な情報収集手法と状況把握技術の習得",
+        "path": "/chapters/chapter02/"
       },
       {
         "id": "chapter03",
         "title": "第3章：論理的な切り分けと原因特定",
-        "description": "体系的な切り分け手法と科学的な原因特定プロセス"
+        "description": "体系的な切り分け手法と科学的な原因特定プロセス",
+        "path": "/chapters/chapter03/"
       },
       {
         "id": "chapter04",
         "title": "第4章：各レイヤーでのトラブルシューティング実践",
-        "description": "ネットワーク、OS、アプリケーション、データベースでの具体的対応法"
+        "description": "ネットワーク、OS、アプリケーション、データベースでの具体的対応法",
+        "path": "/chapters/chapter04/"
       },
       {
         "id": "chapter05",
         "title": "第5章：クラウド環境特有のトラブルシューティング",
-        "description": "AWS、Azure、GCPでのクラウドネイティブな問題解決手法"
+        "description": "AWS、Azure、GCPでのクラウドネイティブな問題解決手法",
+        "path": "/chapters/chapter05/"
       },
       {
         "id": "chapter06",
         "title": "第6章：トラブルからの学びと再発防止",
-        "description": "インシデントレビューと持続的改善のプロセス構築"
+        "description": "インシデントレビューと持続的改善のプロセス構築",
+        "path": "/chapters/chapter06/"
       }
     ],
     "appendices": [
       {
         "id": "appendix-a",
-        "title": "付録A：実践的なコマンドリファレンス",
-        "description": "トラブルシューティングで頻用するコマンドとツールの使用法"
+        "title": "付録A: トラブルシューティング用コマンドリファレンス",
+        "description": "トラブルシューティングで頻用するコマンドとツールの使用法",
+        "path": "/appendices/a/"
       },
       {
         "id": "appendix-b",
-        "title": "付録B：チェックリストとテンプレート",
-        "description": "効率的な問題解決のためのチェックリストとドキュメントテンプレート"
+        "title": "付録B: 診断チェックリスト集",
+        "description": "効率的な問題解決のためのチェックリストとドキュメントテンプレート",
+        "path": "/appendices/b/"
+      },
+      {
+        "id": "appendix-c",
+        "title": "付録C: 設定ファイルサンプル",
+        "description": "調査・復旧・再発防止で参照する設定ファイルサンプル",
+        "path": "/appendices/c/"
+      },
+      {
+        "id": "appendix-d",
+        "title": "付録D: 用語集・技術索引",
+        "description": "トラブルシューティングで使用する主要用語と技術索引",
+        "path": "/appendices/d/"
+      },
+      {
+        "id": "appendix-e",
+        "title": "付録E: 実践ケーススタディ",
+        "description": "実際の障害対応を想定したケーススタディ",
+        "path": "/appendices/e/"
+      },
+      {
+        "id": "appendix-f",
+        "title": "付録F: 継続学習ガイド",
+        "description": "トラブルシューティング能力を継続的に伸ばすための学習ガイド",
+        "path": "/appendices/f/"
       }
     ]
   },
@@ -71,5 +103,6 @@
   "shared": {
     "version": "3.2.2",
     "lastSync": "2026-02-04T23:01:01.194Z"
-  }
+  },
+  "homepage": "https://itdojp.github.io/IT-infra-troubleshooting-book/"
 }

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,6 +7,9 @@ lang: "ja"
 # GitHub Pages設定
 url: "https://itdojp.github.io"
 baseurl: "/IT-infra-troubleshooting-book"
+license: "CC-BY-NC-SA-4.0"
+homepage: "https://itdojp.github.io/IT-infra-troubleshooting-book/"
+repository_url: "https://github.com/itdojp/IT-infra-troubleshooting-book"
 
 # Jekyll設定
 markdown: kramdown
@@ -36,7 +39,7 @@ kramdown:
   syntax_highlighter: rouge
   
 # リポジトリ情報
-repository: 
+repository:
   github: "https://github.com/itdojp/IT-infra-troubleshooting-book"
 
 # Book structure for navigation

--- a/docs/book-config.json
+++ b/docs/book-config.json
@@ -8,45 +8,84 @@
       {
         "id": "chapter01",
         "title": "第1章：トラブルシューティングの基本と心構え",
-        "description": "システム障害の本質的理解と効果的な問題解決の基盤構築"
+        "description": "システム障害の本質的理解と効果的な問題解決の基盤構築",
+        "path": "/chapters/chapter01/"
       },
       {
         "id": "chapter02",
         "title": "第2章：問題の特定と情報収集",
-        "description": "効果的な情報収集手法と状況把握技術の習得"
+        "description": "効果的な情報収集手法と状況把握技術の習得",
+        "path": "/chapters/chapter02/"
       },
       {
         "id": "chapter03",
         "title": "第3章：論理的な切り分けと原因特定",
-        "description": "体系的な切り分け手法と科学的な原因特定プロセス"
+        "description": "体系的な切り分け手法と科学的な原因特定プロセス",
+        "path": "/chapters/chapter03/"
       },
       {
         "id": "chapter04",
         "title": "第4章：各レイヤーでのトラブルシューティング実践",
-        "description": "ネットワーク、OS、アプリケーション、データベースでの具体的対応法"
+        "description": "ネットワーク、OS、アプリケーション、データベースでの具体的対応法",
+        "path": "/chapters/chapter04/"
       },
       {
         "id": "chapter05",
         "title": "第5章：クラウド環境特有のトラブルシューティング",
-        "description": "AWS、Azure、GCPでのクラウドネイティブな問題解決手法"
+        "description": "AWS、Azure、GCPでのクラウドネイティブな問題解決手法",
+        "path": "/chapters/chapter05/"
       },
       {
         "id": "chapter06",
         "title": "第6章：トラブルからの学びと再発防止",
-        "description": "インシデントレビューと持続的改善のプロセス構築"
+        "description": "インシデントレビューと持続的改善のプロセス構築",
+        "path": "/chapters/chapter06/"
       }
     ],
     "appendices": [
       {
         "id": "appendix-a",
-        "title": "付録A：実践的なコマンドリファレンス",
-        "description": "トラブルシューティングで頻用するコマンドとツールの使用法"
+        "title": "付録A: トラブルシューティング用コマンドリファレンス",
+        "description": "トラブルシューティングで頻用するコマンドとツールの使用法",
+        "path": "/appendices/a/"
       },
       {
         "id": "appendix-b",
-        "title": "付録B：チェックリストとテンプレート",
-        "description": "効率的な問題解決のためのチェックリストとドキュメントテンプレート"
+        "title": "付録B: 診断チェックリスト集",
+        "description": "効率的な問題解決のためのチェックリストとドキュメントテンプレート",
+        "path": "/appendices/b/"
+      },
+      {
+        "id": "appendix-c",
+        "title": "付録C: 設定ファイルサンプル",
+        "description": "調査・復旧・再発防止で参照する設定ファイルサンプル",
+        "path": "/appendices/c/"
+      },
+      {
+        "id": "appendix-d",
+        "title": "付録D: 用語集・技術索引",
+        "description": "トラブルシューティングで使用する主要用語と技術索引",
+        "path": "/appendices/d/"
+      },
+      {
+        "id": "appendix-e",
+        "title": "付録E: 実践ケーススタディ",
+        "description": "実際の障害対応を想定したケーススタディ",
+        "path": "/appendices/e/"
+      },
+      {
+        "id": "appendix-f",
+        "title": "付録F: 継続学習ガイド",
+        "description": "トラブルシューティング能力を継続的に伸ばすための学習ガイド",
+        "path": "/appendices/f/"
       }
     ]
+  },
+  "language": "ja",
+  "license": "CC-BY-NC-SA-4.0",
+  "homepage": "https://itdojp.github.io/IT-infra-troubleshooting-book/",
+  "repository": {
+    "url": "https://github.com/itdojp/IT-infra-troubleshooting-book.git",
+    "branch": "main"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
-  "name": "book-formatter",
-  "version": "1.0.0",
+  "name": "it-infra-troubleshooting-book",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "book-formatter",
-      "version": "1.0.0",
+      "name": "it-infra-troubleshooting-book",
+      "version": "1.0.1",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "fs-extra": "^11.2.0",
-        "glob": "^10.3.10",
-        "markdown-it": "^14.1.0",
-        "yaml": "^2.4.1"
+        "glob": "^10.5.0",
+        "markdown-it": "^14.2.0",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "eslint": "^8.57.0",
@@ -758,9 +758,10 @@
       "license": "ISC"
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -791,21 +792,21 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1043,9 +1044,19 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -1081,14 +1092,24 @@
       "license": "ISC"
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -1750,15 +1771,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "book-formatter",
-  "version": "1.0.0",
-  "description": "Book publishing template formatter - converts markdown books to various formats",
+  "name": "it-infra-troubleshooting-book",
+  "version": "1.0.1",
+  "description": "問題解決の思考法から各レイヤーの具体策まで〜システム障害に立ち向かう実践的ガイド〜",
   "main": "src/index.js",
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
-    "test": "node --test tests/BookGenerator.test.js tests/ConfigValidator.test.js",
+    "test": "npm run check:metadata && node --test tests/BookGenerator.test.js tests/ConfigValidator.test.js",
     "format": "prettier --write .",
     "lint": "eslint src/ tests/",
     "build": "cd docs && bundle exec jekyll build",
@@ -18,24 +18,25 @@
     "dashboard:report": "node scripts/dashboard.js --report markdown --save dashboard-report.md",
     "sync-components": "node scripts/sync-components.js",
     "sync-components:all": "node scripts/sync-components.js --all",
-    "sync-components:dry-run": "node scripts/sync-components.js --all --dry-run"
+    "sync-components:dry-run": "node scripts/sync-components.js --all --dry-run",
+    "check:metadata": "node scripts/check-metadata-consistency.js"
   },
   "keywords": [
     "book",
-    "publishing",
-    "markdown",
-    "format",
-    "template"
+    "it-infrastructure",
+    "troubleshooting",
+    "incident-response",
+    "operations"
   ],
-  "author": "ITDO Inc.",
+  "author": "ITDO Inc.（株式会社アイティードゥ）",
   "license": "CC-BY-NC-SA-4.0",
   "dependencies": {
     "commander": "^12.0.0",
-    "markdown-it": "^14.1.0",
-    "yaml": "^2.4.1",
+    "markdown-it": "^14.2.0",
+    "yaml": "^2.9.0",
     "fs-extra": "^11.2.0",
     "chalk": "^5.3.0",
-    "glob": "^10.3.10"
+    "glob": "^10.5.0"
   },
   "devDependencies": {
     "prettier": "^3.2.5",
@@ -43,5 +44,13 @@
   },
   "engines": {
     "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/itdojp/IT-infra-troubleshooting-book.git"
+  },
+  "homepage": "https://itdojp.github.io/IT-infra-troubleshooting-book/",
+  "bugs": {
+    "url": "https://github.com/itdojp/IT-infra-troubleshooting-book/issues"
   }
 }

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -1,0 +1,393 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import util from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const REPO_SLUG = 'IT-infra-troubleshooting-book';
+const GITHUB_URL = `https://github.com/itdojp/${REPO_SLUG}`;
+const GITHUB_GIT_URL = `${GITHUB_URL}.git`;
+const PACKAGE_GIT_URL = `git+${GITHUB_GIT_URL}`;
+const PAGES_URL = `https://itdojp.github.io/${REPO_SLUG}/`;
+const ISSUES_URL = `${GITHUB_URL}/issues`;
+const EXPECTED_PACKAGE_NAME = 'it-infra-troubleshooting-book';
+const EXPECTED_DOC_ASSETS = [
+  'assets/css/main.css',
+  'assets/css/mobile-responsive.css',
+  'assets/css/syntax-highlighting.css',
+  'assets/js/theme.js',
+  'assets/js/search.js',
+  'assets/js/code-copy-lightweight.js',
+  'assets/images/itdo_logo_48x48_blue.png',
+];
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const docsDir = path.join(root, 'docs');
+const errors = [];
+
+function repoPath(...parts) {
+  return path.join(root, ...parts);
+}
+
+function display(file) {
+  return path.relative(root, file).replaceAll(path.sep, '/') || '.';
+}
+
+function readText(relPath) {
+  const file = repoPath(relPath);
+  try {
+    return fs.readFileSync(file, 'utf8');
+  } catch (error) {
+    errors.push(`${relPath}: ${error.message}`);
+    return '';
+  }
+}
+
+function readJson(relPath) {
+  const file = repoPath(relPath);
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    errors.push(`${relPath}: invalid JSON: ${error.message}`);
+    return {};
+  }
+}
+
+function stripYamlScalar(raw) {
+  if (raw == null) return '';
+  let value = String(raw).trim();
+  if (!value) return '';
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    value = value.slice(1, -1);
+  }
+  return value.trim();
+}
+
+function parseRootScalars(yamlText) {
+  const scalars = {};
+  for (const line of yamlText.split(/\r?\n/)) {
+    const match = line.match(/^([A-Za-z0-9_]+):\s*(.*?)\s*$/);
+    if (!match) continue;
+    const [, key, raw] = match;
+    if (raw === '') continue;
+    scalars[key] = stripYamlScalar(raw);
+  }
+  return scalars;
+}
+
+function parseRepositoryGithub(yamlText) {
+  const lines = yamlText.split(/\r?\n/);
+  let inRepository = false;
+  for (const line of lines) {
+    if (/^repository:\s*$/.test(line)) {
+      inRepository = true;
+      continue;
+    }
+    if (inRepository && /^\S/.test(line)) {
+      inRepository = false;
+    }
+    if (!inRepository) continue;
+    const match = line.match(/^\s+github:\s*(.*?)\s*$/);
+    if (match) return stripYamlScalar(match[1]);
+  }
+  return '';
+}
+
+function normalizeRoute(raw, context) {
+  if (typeof raw !== 'string') {
+    errors.push(`${context}: path must be a string`);
+    return null;
+  }
+  let route = raw.trim();
+  if (!route) {
+    errors.push(`${context}: path is empty`);
+    return null;
+  }
+  if (/^(https?:|mailto:)/i.test(route)) {
+    errors.push(`${context}: external paths are not allowed in book navigation (${route})`);
+    return null;
+  }
+  if (route.includes('..')) {
+    errors.push(`${context}: path must not contain '..' (${route})`);
+    return null;
+  }
+  if (!route.startsWith('/')) route = `/${route}`;
+  if (route !== '/' && !/[./][A-Za-z0-9]+$/.test(route) && !route.endsWith('/')) route += '/';
+  return route;
+}
+
+function parseNavigation(yamlText) {
+  const sections = {};
+  let currentKey = null;
+  let currentItem = null;
+
+  const flush = () => {
+    if (!currentKey || !currentItem) return;
+    sections[currentKey] ??= [];
+    sections[currentKey].push(currentItem);
+    currentItem = null;
+  };
+
+  for (const line of yamlText.split(/\r?\n/)) {
+    const sectionMatch = line.match(/^([A-Za-z0-9_]+):\s*$/);
+    if (sectionMatch) {
+      flush();
+      currentKey = sectionMatch[1];
+      continue;
+    }
+    if (!currentKey) continue;
+    const titleMatch = line.match(/^\s*-\s+title:\s*(.*?)\s*$/);
+    if (titleMatch) {
+      flush();
+      currentItem = { title: stripYamlScalar(titleMatch[1]) };
+      continue;
+    }
+    const directPathMatch = line.match(/^\s*-\s+path:\s*(.*?)\s*$/);
+    if (directPathMatch) {
+      flush();
+      currentItem = { path: stripYamlScalar(directPathMatch[1]) };
+      continue;
+    }
+    const pathMatch = line.match(/^\s+path:\s*(.*?)\s*$/);
+    if (pathMatch && currentItem) {
+      currentItem.path = stripYamlScalar(pathMatch[1]);
+    }
+  }
+  flush();
+  return sections;
+}
+
+function parseConfigStructurePaths(yamlText) {
+  const paths = [];
+  let inStructure = false;
+  for (const line of yamlText.split(/\r?\n/)) {
+    if (/^structure:\s*$/.test(line)) {
+      inStructure = true;
+      continue;
+    }
+    if (inStructure && /^\S/.test(line)) break;
+    if (!inStructure) continue;
+    const match = line.match(/^\s+path:\s*(.*?)\s*$/);
+    if (match) paths.push(stripYamlScalar(match[1]));
+  }
+  return paths;
+}
+
+function parseFrontMatter(relPath) {
+  const text = readText(relPath);
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    errors.push(`${relPath}: missing YAML front matter`);
+    return {};
+  }
+  const front = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const scalar = line.match(/^([A-Za-z0-9_-]+):\s*(.*?)\s*$/);
+    if (!scalar) continue;
+    front[scalar[1]] = stripYamlScalar(scalar[2]);
+  }
+  return front;
+}
+
+function routeCandidates(route) {
+  if (route === '/') return [path.join(docsDir, 'index.md')];
+  const rel = route.replace(/^\//, '');
+  const candidates = [];
+  if (rel.endsWith('/')) {
+    const dirRel = rel.slice(0, -1);
+    candidates.push(path.join(docsDir, dirRel, 'index.md'));
+    candidates.push(path.join(docsDir, `${dirRel}.md`));
+  } else {
+    candidates.push(path.join(docsDir, rel));
+    candidates.push(path.join(docsDir, `${rel}.md`));
+    candidates.push(path.join(docsDir, rel, 'index.md'));
+  }
+  return candidates;
+}
+
+function routeExists(route) {
+  return routeCandidates(route).some((candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isFile());
+}
+
+function expectEqual(actual, expected, label) {
+  if (actual !== expected) {
+    errors.push(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectDeepEqual(actual, expected, label) {
+  if (!util.isDeepStrictEqual(actual, expected)) {
+    errors.push(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function ensureArray(data, label) {
+  if (!Array.isArray(data)) {
+    errors.push(`${label}: expected an array`);
+    return [];
+  }
+  return data;
+}
+
+const bookConfig = readJson('book-config.json');
+const publicBookConfig = readJson('docs/book-config.json');
+const packageJson = readJson('package.json');
+const packageLock = readJson('package-lock.json');
+const docsConfigText = readText('docs/_config.yml');
+const navigationText = readText('docs/_data/navigation.yml');
+const docsIndexFrontMatter = parseFrontMatter('docs/index.md');
+const docsConfig = parseRootScalars(docsConfigText);
+const navigation = parseNavigation(navigationText);
+const navEntries = [
+  ...ensureArray(navigation.introduction, 'docs/_data/navigation.yml introduction'),
+  ...ensureArray(navigation.chapters, 'docs/_data/navigation.yml chapters'),
+  ...ensureArray(navigation.appendices, 'docs/_data/navigation.yml appendices'),
+];
+const navChapterEntries = ensureArray(navigation.chapters, 'docs/_data/navigation.yml chapters');
+const navAppendixEntries = ensureArray(navigation.appendices, 'docs/_data/navigation.yml appendices');
+const normalizedNavEntries = navEntries.map((item, index) => ({
+  title: item.title,
+  path: normalizeRoute(item.path, `docs/_data/navigation.yml entry ${index + 1}`),
+}));
+
+const canonical = {
+  title: bookConfig.title,
+  description: bookConfig.description,
+  author: bookConfig.author,
+  version: bookConfig.version,
+  language: bookConfig.language,
+  license: bookConfig.license,
+  homepage: PAGES_URL,
+  repository: { url: GITHUB_GIT_URL, branch: 'main' },
+};
+
+for (const [relPath, config] of [
+  ['book-config.json', bookConfig],
+  ['docs/book-config.json', publicBookConfig],
+]) {
+  expectEqual(config.title, canonical.title, `${relPath} title`);
+  expectEqual(config.description, canonical.description, `${relPath} description`);
+  expectEqual(config.author, canonical.author, `${relPath} author`);
+  expectEqual(config.version, canonical.version, `${relPath} version`);
+  expectEqual(config.language, canonical.language, `${relPath} language`);
+  expectEqual(config.license, canonical.license, `${relPath} license`);
+  expectEqual(config.homepage, PAGES_URL, `${relPath} homepage`);
+  expectDeepEqual(config.repository, canonical.repository, `${relPath} repository`);
+}
+
+expectEqual(packageJson.name, EXPECTED_PACKAGE_NAME, 'package.json name');
+expectEqual(packageJson.version, canonical.version, 'package.json version');
+expectEqual(packageJson.description, canonical.description, 'package.json description');
+expectEqual(packageJson.author, canonical.author, 'package.json author');
+expectEqual(packageJson.license, canonical.license, 'package.json license');
+expectDeepEqual(packageJson.repository, { type: 'git', url: PACKAGE_GIT_URL }, 'package.json repository');
+expectEqual(packageJson.homepage, PAGES_URL, 'package.json homepage');
+expectDeepEqual(packageJson.bugs, { url: ISSUES_URL }, 'package.json bugs');
+expectEqual(packageJson.scripts?.['check:metadata'], 'node scripts/check-metadata-consistency.js', 'package.json scripts.check:metadata');
+if (!String(packageJson.scripts?.test || '').includes('npm run check:metadata')) {
+  errors.push('package.json scripts.test: expected to run npm run check:metadata');
+}
+
+expectEqual(packageLock.name, EXPECTED_PACKAGE_NAME, 'package-lock.json name');
+expectEqual(packageLock.version, canonical.version, 'package-lock.json version');
+expectEqual(packageLock.packages?.['']?.name, EXPECTED_PACKAGE_NAME, 'package-lock.json packages[""].name');
+expectEqual(packageLock.packages?.['']?.version, canonical.version, 'package-lock.json packages[""].version');
+
+for (const [key, expected] of [
+  ['title', canonical.title],
+  ['description', canonical.description],
+  ['author', canonical.author],
+  ['version', canonical.version],
+  ['lang', 'ja'],
+  ['url', 'https://itdojp.github.io'],
+  ['baseurl', `/${REPO_SLUG}`],
+  ['license', canonical.license],
+  ['homepage', PAGES_URL],
+  ['repository_url', GITHUB_URL],
+]) {
+  expectEqual(docsConfig[key], expected, `docs/_config.yml ${key}`);
+}
+expectEqual(parseRepositoryGithub(docsConfigText), GITHUB_URL, 'docs/_config.yml repository.github');
+
+for (const [key, expected] of [
+  ['title', canonical.title],
+  ['description', canonical.description],
+  ['author', canonical.author],
+  ['version', canonical.version],
+]) {
+  expectEqual(docsIndexFrontMatter[key], expected, `docs/index.md front matter ${key}`);
+}
+
+function structureEntries(config, section, label) {
+  return ensureArray(config.structure?.[section], `${label} structure.${section}`).map((item, index) => {
+    const route = normalizeRoute(item.path, `${label} structure.${section}[${index}].path`);
+    return {
+      id: item.id,
+      title: item.title,
+      description: item.description,
+      path: route,
+    };
+  });
+}
+
+const expectedChapters = navChapterEntries.map((item, index) => ({
+  id: `chapter${String(index + 1).padStart(2, '0')}`,
+  title: item.title,
+  description: bookConfig.structure.chapters?.[index]?.description,
+  path: normalizeRoute(item.path, `expected chapter ${index + 1}`),
+}));
+const appendixIds = ['appendix-a', 'appendix-b', 'appendix-c', 'appendix-d', 'appendix-e', 'appendix-f'];
+const expectedAppendices = navAppendixEntries.map((item, index) => ({
+  id: appendixIds[index],
+  title: item.title,
+  description: bookConfig.structure.appendices?.[index]?.description,
+  path: normalizeRoute(item.path, `expected appendix ${index + 1}`),
+}));
+
+for (const [label, config] of [
+  ['book-config.json', bookConfig],
+  ['docs/book-config.json', publicBookConfig],
+]) {
+  expectDeepEqual(structureEntries(config, 'chapters', label), expectedChapters, `${label} structure.chapters`);
+  expectDeepEqual(structureEntries(config, 'appendices', label), expectedAppendices, `${label} structure.appendices`);
+}
+
+const structureConfigPaths = parseConfigStructurePaths(docsConfigText).map((p, index) => normalizeRoute(p, `docs/_config.yml structure path ${index + 1}`));
+const expectedStructureRoutes = [...expectedChapters, ...expectedAppendices].map((entry) => entry.path);
+expectDeepEqual(structureConfigPaths, expectedStructureRoutes, 'docs/_config.yml structure paths');
+
+const seen = new Map();
+for (const [index, entry] of normalizedNavEntries.entries()) {
+  if (!entry.path) continue;
+  if (seen.has(entry.path)) {
+    errors.push(`docs/_data/navigation.yml: duplicate path ${entry.path} at entries ${seen.get(entry.path)} and ${index + 1}`);
+  } else {
+    seen.set(entry.path, index + 1);
+  }
+  if (!routeExists(entry.path)) {
+    const candidates = routeCandidates(entry.path).map(display).join(', ');
+    errors.push(`docs/_data/navigation.yml: path ${entry.path} has no matching Markdown source (${candidates})`);
+  }
+}
+
+for (const route of expectedStructureRoutes) {
+  if (!seen.has(route)) {
+    errors.push(`book structure route ${route} is missing from docs/_data/navigation.yml`);
+  }
+}
+
+for (const asset of EXPECTED_DOC_ASSETS) {
+  const assetPath = path.join(docsDir, asset);
+  if (!fs.existsSync(assetPath) || !fs.statSync(assetPath).isFile() || fs.statSync(assetPath).size === 0) {
+    errors.push(`docs/${asset}: required public asset is missing or empty`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`Metadata consistency check failed with ${errors.length} issue(s):`);
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log(`OK: metadata, navigation, structure, and required assets are consistent (${normalizedNavEntries.length} navigation entries)`);


### PR DESCRIPTION
## Summary
- add a stdlib-only `check:metadata` gate that validates public book metadata, navigation routes, structure entries, package/package-lock metadata, and required Pages assets
- align root/public `book-config.json` appendix structure with the current published A-F appendices and add route/homepage/repository metadata
- normalize package metadata and refresh production lockfile entries so the production/non-optional audit is clean
- wire the metadata check into local `npm test` and Book QA, and document the local quality workflow

## Validation
- `node --check scripts/check-metadata-consistency.js`
- `npm run check:metadata`
- `(cd docs && node ../scripts/check-metadata-consistency.js)`
- `npm test` (33 tests passed)
- `npm audit --omit=dev --omit=optional` (0 vulnerabilities)
- `git diff --check`
- workflow YAML parse for `.github/workflows/*.yml`
- fixture checks: package homepage drift, missing navigation target, duplicate navigation target, missing structure path, external structure path fail with actionable errors; CRLF front matter positive case passes
- pinned `itdojp/book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4` checks: unicode, textlint/PRH, internal links, layout risk, markdown structure
- Jekyll build from `docs/` and built-site smoke for top, chapter01, chapter06, appendix A, appendix F, introduction prerequisites, and required assets

## Notes
- This repository tracks `node_modules`; dependency remediation was intentionally limited to `package.json`/`package-lock.json` to avoid committing tracked dependency-tree churn.