### PR TITLE
Fix mobile sidebar closed state

### DIFF
--- a/IT-infra-troubleshooting-book/docs/assets/css/mobile-responsive.css
+++ b/IT-infra-troubleshooting-book/docs/assets/css/mobile-responsive.css
@@ -49,7 +49,14 @@ html {
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
     z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and portrait tablet widths. The checked/open rule below is
+     * more specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -54,7 +54,14 @@ html {
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
     z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and portrait tablet widths. The checked/open rule below is
+     * more specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 


### PR DESCRIPTION
## Summary
- keep the mobile/tablet closed sidebar drawer off-canvas with `!important`
- apply the same fix to the tracked nested published copy
- document why the imported mobile rule must win over the later desktop sidebar transform in `main.css`

## Rationale
`main.css` imports `mobile-responsive.css` before declaring the default desktop `.book-sidebar { transform: translateX(0); }` rule. At mobile and portrait tablet widths, the later desktop transform can override the closed drawer state and leave the TOC overlapping article content. The checked/open rule is already more specific and `!important`, so the menu button behavior remains unchanged.

## Verification
- `npm ci`
- `npm test`
- `cd docs && bundle install` with workspace-local `BUNDLE_PATH`
- `npm run build`
- `git diff --check`
- Local Pages visual checker: Chromium, `phone480`, `tablet`, `tablet820`, `laptop1024`, `desktop`, `maxPagesPerBook=2`, `skipScreenshots`, `enforceFontSpec` → `books=1 pages=10 ok=10 warn=0 fail=0`
- Direct Playwright probe for `/` and `/introduction/` at 480/768/820/1024/1280 px confirmed:
  - closed drawer is off-canvas on mobile/tablet
  - sidebar does not overlay content while closed
  - toggle opens the drawer
  - desktop sidebar/content layout remains unchanged

Part of itdojp/it-engineer-knowledge-architecture#168.
