### PR TITLE
metadata: align UX modules with published guides

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -91,13 +91,13 @@
     "profile": "B",
     "modules": {
       "quickStart": false,
-      "readingGuide": false,
+      "readingGuide": true,
       "checklistPack": true,
       "troubleshootingFlow": true,
       "conceptMap": false,
       "figureIndex": true,
       "legalNotice": false,
-      "glossary": false
+      "glossary": true
     }
   },
   "shared": {


### PR DESCRIPTION
## 変更

- 公開トップの読み方ガイドに合わせて readingGuide=true
- 公開付録Dの用語集・技術索引に合わせて glossary=true
- Profile B、チェックリスト、トラブルシューティング、主要図版導線など他の値は維持

## 根拠

固定main SHA 15b54e2781b61bff6f7f9c1301930b7d6669550b の docs/index.md、docs/appendices/b.md、docs/appendices/d.md、navigationを照合した。

## 検証

- npm ci
- npm test: 33 tests passed
- npm run build: success
- npm audit --omit=dev --omit=optional: 0
- git diff --check

full npm auditの既存dev依存5件は #140 で分離追跡する。npm ciで変更された追跡済みnode_modulesは復元し、本PRには含めない。

Closes #139
Parent: itdojp/it-engineer-knowledge-architecture#211
