### PR TITLE
deps: update brace-expansion to patched release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -792,9 +792,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"


### PR DESCRIPTION
## 概要

`glob@10.5.0 > minimatch` 配下の `brace-expansion` を、DoS advisory `GHSA-3jxr-9vmj-r5cp` の修正済みリリースへ lockfile 上で更新します。

## 変更

- `package-lock.json` の nested `brace-expansion` を `2.1.1` から `2.1.2` へ更新
- direct dependency range、`package.json`、本文、formatter pin、workflowは変更しない
- repositoryで追跡されている `node_modules` は検証後に復元し、PR差分へ含めない

## 検証

Node.js 24環境で以下を確認しました。

- `npm ci --ignore-scripts`
- `npm audit`: 0 vulnerabilities
- `npm audit --omit=dev --omit=optional`: 0 vulnerabilities
- `npm audit --package-lock-only`: 0 vulnerabilities
- `npm audit --package-lock-only --omit=dev --omit=optional`: 0 vulnerabilities
- `npm test`: 33/33 passed
- `npm run lint`: passed
- `npm run build`: passed
- `git diff --check`: passed

`npm run build` では既存の Faraday retry middleware の案内が出ますが、buildは成功しており、本PRの依存脆弱性とは別スコープです。

Closes #150
