### PR TITLE
docs: modernize MySQL binary log settings

### DIFF
--- a/docs/appendices/c.md
+++ b/docs/appendices/c.md
@@ -406,7 +406,7 @@ SELECT @@version AS version,
 
 MariaDBは別製品です。MariaDB 10.6.1以降にも`binlog_expire_logs_seconds`がありますが、`expire_logs_days`とのalias関係や`binlog_format`のdefault・変更契約はOracle MySQL 8.0と同一ではありません。採用中のMariaDB versionの公式system variableを確認してください。
 
-公式情報（2026-07-21確認）:
+公式情報（2026-07-21 JST確認）:
 
 - [MySQL 8.0: Binary Logging Options and Variables](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html)
 - [MySQL 8.0.34 Release Notes: binlog_format deprecation](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-34.html)

--- a/docs/appendices/c.md
+++ b/docs/appendices/c.md
@@ -324,6 +324,8 @@ server {
 
 ### MySQL/MariaDB
 
+この節の一般設定は構成例です。製品間でparameterのdefault、廃止時期、反映方法が異なるため、後半のbinary log例はOracle MySQL向けのbaselineとして分離し、MariaDBへそのまま流用しません。
+
 **推奨度**: 条件付き（環境/ワークロードに合わせて調整。デフォルト値を鵜呑みにしない）  
 **副作用/注意**: 設定変更は性能/互換性/安定性に影響する。反映に再起動が必要な項目があるため、検証環境で事前確認する。
 
@@ -365,18 +367,51 @@ bind-address = 127.0.0.1
 # ssl-cert = /etc/mysql/ssl/server-cert.pem
 # ssl-key = /etc/mysql/ssl/server-key.pem
 
-# レプリケーション設定
-server-id = 1
-log-bin = mysql-bin
-binlog-format = ROW
-expire_logs_days = 7
-
 [mysql]
 default-character-set = utf8mb4
 
 [client]
 default-character-set = utf8mb4
 ```
+
+#### Binary log設定（Oracle MySQL 8.0.34以降）
+
+次はOracle MySQL 8.0.34以降の新規installationをbaselineとする例です。MySQL 8.0ではbinary logとROW formatがdefaultであり、8.0.34以降は`binlog_format`変数とformat変更自体がdeprecatedです。そのため、主例では`binlog_format`を明示せず、binary logのbasenameとretentionだけを設定します。
+
+```ini
+[mysqld]
+# replicationを使用する場合、server-idは各serverで一意にする
+server-id = 1
+
+# binary logのbasenameを明示する
+log-bin = mysql-bin
+
+# 自動purgeを有効にし、例として7日（604800秒）保持する
+binlog_expire_logs_auto_purge = ON
+binlog_expire_logs_seconds = 604800
+```
+
+`604800`は例示値です。最大replica lagに運用余裕を加えた期間を下回らず、point-in-time recoveryとbackup policyが要求する復旧可能期間を満たす値にします。短縮前には全replicaの適用位置と必要なbackupを確認してください。
+
+`log-bin`の有効化やbasename変更はstartup optionなので、設定反映には計画restartが必要です。反映後はdeprecated変数を参照せず、次のSQLでversion、binary log、自動purge、retentionを確認します。
+
+```sql
+SELECT @@version AS version,
+       @@global.log_bin AS log_bin,
+       @@global.binlog_expire_logs_auto_purge AS auto_purge,
+       @@global.binlog_expire_logs_seconds AS retention_seconds;
+```
+
+既存のSTATEMENT/MIXED環境では、明示設定だけを削除するとrestart後のevent形式が変わり得ます。application、temporary table、replicaの互換性を評価し、公式のreplication format移行手順に従ってROW移行を完了してから設定を除去してください。
+
+MariaDBは別製品です。MariaDB 10.6.1以降にも`binlog_expire_logs_seconds`がありますが、`expire_logs_days`とのalias関係や`binlog_format`のdefault・変更契約はOracle MySQL 8.0と同一ではありません。採用中のMariaDB versionの公式system variableを確認してください。
+
+公式情報（2026-07-21確認）:
+
+- [MySQL 8.0: Binary Logging Options and Variables](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html)
+- [MySQL 8.0.34 Release Notes: binlog_format deprecation](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-34.html)
+- [MySQL 8.0: Replication Formats](https://dev.mysql.com/doc/refman/8.0/en/replication-formats.html)
+- [MariaDB: Replication and Binary Log System Variables](https://mariadb.com/docs/server/ha-and-performance/standard-replication/replication-and-binary-log-system-variables)
 
 ### PostgreSQL
 

--- a/manuscript/appendices/c.md
+++ b/manuscript/appendices/c.md
@@ -303,6 +303,8 @@ server {
 
 ### MySQL/MariaDB
 
+この節の一般設定は構成例です。製品間でparameterのdefault、廃止時期、反映方法が異なるため、後半のbinary log例はOracle MySQL向けのbaselineとして分離し、MariaDBへそのまま流用しません。
+
 #### /etc/my.cnf
 ```ini
 [mysqld]
@@ -339,18 +341,51 @@ bind-address = 127.0.0.1
 # ssl-cert = /etc/mysql/ssl/server-cert.pem
 # ssl-key = /etc/mysql/ssl/server-key.pem
 
-# レプリケーション設定
-server-id = 1
-log-bin = mysql-bin
-binlog-format = ROW
-expire_logs_days = 7
-
 [mysql]
 default-character-set = utf8mb4
 
 [client]
 default-character-set = utf8mb4
 ```
+
+#### Binary log設定（Oracle MySQL 8.0.34以降）
+
+次はOracle MySQL 8.0.34以降の新規installationをbaselineとする例です。MySQL 8.0ではbinary logとROW formatがdefaultであり、8.0.34以降は`binlog_format`変数とformat変更自体がdeprecatedです。そのため、主例では`binlog_format`を明示せず、binary logのbasenameとretentionだけを設定します。
+
+```ini
+[mysqld]
+# replicationを使用する場合、server-idは各serverで一意にする
+server-id = 1
+
+# binary logのbasenameを明示する
+log-bin = mysql-bin
+
+# 自動purgeを有効にし、例として7日（604800秒）保持する
+binlog_expire_logs_auto_purge = ON
+binlog_expire_logs_seconds = 604800
+```
+
+`604800`は例示値です。最大replica lagに運用余裕を加えた期間を下回らず、point-in-time recoveryとbackup policyが要求する復旧可能期間を満たす値にします。短縮前には全replicaの適用位置と必要なbackupを確認してください。
+
+`log-bin`の有効化やbasename変更はstartup optionなので、設定反映には計画restartが必要です。反映後はdeprecated変数を参照せず、次のSQLでversion、binary log、自動purge、retentionを確認します。
+
+```sql
+SELECT @@version AS version,
+       @@global.log_bin AS log_bin,
+       @@global.binlog_expire_logs_auto_purge AS auto_purge,
+       @@global.binlog_expire_logs_seconds AS retention_seconds;
+```
+
+既存のSTATEMENT/MIXED環境では、明示設定だけを削除するとrestart後のevent形式が変わり得ます。application、temporary table、replicaの互換性を評価し、公式のreplication format移行手順に従ってROW移行を完了してから設定を除去してください。
+
+MariaDBは別製品です。MariaDB 10.6.1以降にも`binlog_expire_logs_seconds`がありますが、`expire_logs_days`とのalias関係や`binlog_format`のdefault・変更契約はOracle MySQL 8.0と同一ではありません。採用中のMariaDB versionの公式system variableを確認してください。
+
+公式情報（2026-07-21確認）:
+
+- [MySQL 8.0: Binary Logging Options and Variables](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html)
+- [MySQL 8.0.34 Release Notes: binlog_format deprecation](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-34.html)
+- [MySQL 8.0: Replication Formats](https://dev.mysql.com/doc/refman/8.0/en/replication-formats.html)
+- [MariaDB: Replication and Binary Log System Variables](https://mariadb.com/docs/server/ha-and-performance/standard-replication/replication-and-binary-log-system-variables)
 
 ### PostgreSQL
 

--- a/manuscript/appendices/c.md
+++ b/manuscript/appendices/c.md
@@ -380,7 +380,7 @@ SELECT @@version AS version,
 
 MariaDBは別製品です。MariaDB 10.6.1以降にも`binlog_expire_logs_seconds`がありますが、`expire_logs_days`とのalias関係や`binlog_format`のdefault・変更契約はOracle MySQL 8.0と同一ではありません。採用中のMariaDB versionの公式system variableを確認してください。
 
-公式情報（2026-07-21確認）:
+公式情報（2026-07-21 JST確認）:
 
 - [MySQL 8.0: Binary Logging Options and Variables](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html)
 - [MySQL 8.0.34 Release Notes: binlog_format deprecation](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-34.html)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
-    "test": "npm run check:metadata && npm run test:network-config && node --test tests/BookGenerator.test.js tests/ConfigValidator.test.js",
+    "test": "npm run check:metadata && npm run test:network-config && npm run test:mysql-binlog && node --test tests/BookGenerator.test.js tests/ConfigValidator.test.js",
     "format": "prettier --write .",
     "lint": "eslint src/ tests/",
     "build": "cd docs && bundle exec jekyll build",
@@ -21,7 +21,9 @@
     "sync-components:dry-run": "node scripts/sync-components.js --all --dry-run",
     "check:metadata": "node scripts/check-metadata-consistency.js",
     "check:network-config": "node scripts/check-network-config-modernization.js",
-    "test:network-config": "node --test scripts/check-network-config-modernization.test.js"
+    "test:network-config": "node --test scripts/check-network-config-modernization.test.js",
+    "check:mysql-binlog": "node scripts/check-mysql-binlog-modernization.js",
+    "test:mysql-binlog": "node --test scripts/check-mysql-binlog-modernization.test.js"
   },
   "keywords": [
     "book",

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -5,6 +5,7 @@ import process from 'node:process';
 import util from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { validateNetworkConfigModernization } from './check-network-config-modernization.js';
+import { validateMysqlBinlogModernization } from './check-mysql-binlog-modernization.js';
 
 const REPO_SLUG = 'IT-infra-troubleshooting-book';
 const GITHUB_URL = `https://github.com/itdojp/${REPO_SLUG}`;
@@ -387,6 +388,12 @@ for (const asset of EXPECTED_DOC_ASSETS) {
 
 try {
   validateNetworkConfigModernization(root);
+} catch (error) {
+  errors.push(error instanceof Error ? error.message : String(error));
+}
+
+try {
+  validateMysqlBinlogModernization(root);
 } catch (error) {
   errors.push(error instanceof Error ? error.message : String(error));
 }

--- a/scripts/check-mysql-binlog-modernization.js
+++ b/scripts/check-mysql-binlog-modernization.js
@@ -66,14 +66,15 @@ export function validateMysqlBinlogTexts(manuscript, docs) {
         `${label} appendix C contains a deprecated MySQL binary log assignment`,
       );
     }
+    const extracted = extractSection(text, label);
     for (const marker of requiredMarkers) {
-      if (!text.includes(marker)) {
+      if (!extracted.includes(marker)) {
         throw new MysqlBinlogContractError(
           `${label} appendix C is missing required MySQL binary log marker ${JSON.stringify(marker)}`,
         );
       }
     }
-    sections[label] = extractSection(text, label);
+    sections[label] = extracted;
   }
 
   if (sections.manuscript !== sections.docs) {

--- a/scripts/check-mysql-binlog-modernization.js
+++ b/scripts/check-mysql-binlog-modernization.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export class MysqlBinlogContractError extends Error {}
+
+const appendixPaths = {
+  manuscript: 'manuscript/appendices/c.md',
+  docs: 'docs/appendices/c.md',
+};
+
+const section = {
+  start: '#### Binary log設定（Oracle MySQL 8.0.34以降）',
+  end: '### PostgreSQL',
+};
+
+const requiredMarkers = [
+  'Oracle MySQL 8.0.34以降の新規installation',
+  'MySQL 8.0ではbinary logとROW formatがdefault',
+  'binlog_expire_logs_auto_purge = ON',
+  'binlog_expire_logs_seconds = 604800',
+  '最大replica lagに運用余裕を加えた期間',
+  'point-in-time recoveryとbackup policy',
+  'deprecated変数を参照せず',
+  '@@global.binlog_expire_logs_auto_purge',
+  '@@global.binlog_expire_logs_seconds',
+  '既存のSTATEMENT/MIXED環境',
+  'MariaDBは別製品',
+  'MariaDB 10.6.1以降',
+  'https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html',
+  'https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-34.html',
+  'https://dev.mysql.com/doc/refman/8.0/en/replication-formats.html',
+  'https://mariadb.com/docs/server/ha-and-performance/standard-replication/replication-and-binary-log-system-variables',
+];
+
+const deprecatedAssignments = /^\s*(?:expire_logs_days|binlog[-_]format)\s*=/im;
+
+function readRequired(root, relativePath) {
+  try {
+    return fs.readFileSync(path.join(root, relativePath), 'utf8');
+  } catch (error) {
+    throw new MysqlBinlogContractError(
+      `MySQL binary log contract could not read ${relativePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function extractSection(text, label) {
+  const start = text.indexOf(section.start);
+  if (start < 0) {
+    throw new MysqlBinlogContractError(`${label} appendix C is missing the MySQL 8.0.34 binary log section`);
+  }
+  const end = text.indexOf(section.end, start + section.start.length);
+  if (end < 0) {
+    throw new MysqlBinlogContractError(`${label} appendix C is missing the PostgreSQL boundary`);
+  }
+  return text.slice(start, end).trim();
+}
+
+export function validateMysqlBinlogTexts(manuscript, docs) {
+  const sections = {};
+  for (const [label, text] of Object.entries({ manuscript, docs })) {
+    if (deprecatedAssignments.test(text)) {
+      throw new MysqlBinlogContractError(
+        `${label} appendix C contains a deprecated MySQL binary log assignment`,
+      );
+    }
+    for (const marker of requiredMarkers) {
+      if (!text.includes(marker)) {
+        throw new MysqlBinlogContractError(
+          `${label} appendix C is missing required MySQL binary log marker ${JSON.stringify(marker)}`,
+        );
+      }
+    }
+    sections[label] = extractSection(text, label);
+  }
+
+  if (sections.manuscript !== sections.docs) {
+    throw new MysqlBinlogContractError(
+      'MySQL 8.0.34 binary log section differs between manuscript/appendices/c.md and docs/appendices/c.md',
+    );
+  }
+
+  return { synchronizedSectionCount: 1 };
+}
+
+export function validateMysqlBinlogModernization(
+  root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'),
+) {
+  return validateMysqlBinlogTexts(
+    readRequired(root, appendixPaths.manuscript),
+    readRequired(root, appendixPaths.docs),
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const result = validateMysqlBinlogModernization();
+    console.log(
+      `OK: MySQL binary log parameters are current and synchronized (${result.synchronizedSectionCount} section)`,
+    );
+  } catch (error) {
+    console.error(`ERROR: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}

--- a/scripts/check-mysql-binlog-modernization.test.js
+++ b/scripts/check-mysql-binlog-modernization.test.js
@@ -48,7 +48,8 @@ test('rejects an explicit deprecated binlog_format assignment', () => {
 
 test('rejects loss of the MariaDB product and version boundary', () => {
   const { manuscript, docs } = canonicalTexts();
-  const regressed = manuscript.replace('MariaDB 10.6.1以降', 'MariaDB version unspecified');
+  const marker = 'MariaDB 10.6.1以降';
+  const regressed = `${manuscript.replace(marker, 'MariaDB version unspecified')}\n\n${marker}\n`;
   assert.throws(
     () => validateMysqlBinlogTexts(regressed, docs),
     /missing required MySQL binary log marker.*MariaDB 10\.6\.1/,

--- a/scripts/check-mysql-binlog-modernization.test.js
+++ b/scripts/check-mysql-binlog-modernization.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { validateMysqlBinlogTexts } from './check-mysql-binlog-modernization.js';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function canonicalTexts() {
+  return {
+    manuscript: fs.readFileSync(path.join(root, 'manuscript/appendices/c.md'), 'utf8'),
+    docs: fs.readFileSync(path.join(root, 'docs/appendices/c.md'), 'utf8'),
+  };
+}
+
+test('accepts the Oracle MySQL 8.0.34 baseline with source/public parity', () => {
+  const { manuscript, docs } = canonicalTexts();
+  assert.deepEqual(validateMysqlBinlogTexts(manuscript, docs), { synchronizedSectionCount: 1 });
+  assert.deepEqual(
+    validateMysqlBinlogTexts(manuscript.replaceAll('\n', '\r\n'), docs.replaceAll('\n', '\r\n')),
+    { synchronizedSectionCount: 1 },
+  );
+});
+
+test('rejects expire_logs_days assignments in either canonical copy', () => {
+  const { manuscript, docs } = canonicalTexts();
+  for (const [source, publicCopy] of [
+    [manuscript.replace('binlog_expire_logs_seconds = 604800', 'expire_logs_days = 7'), docs],
+    [manuscript, docs.replace('binlog_expire_logs_seconds = 604800', 'expire_logs_days = 7')],
+  ]) {
+    assert.throws(
+      () => validateMysqlBinlogTexts(source, publicCopy),
+      /deprecated MySQL binary log assignment/,
+    );
+  }
+});
+
+test('rejects an explicit deprecated binlog_format assignment', () => {
+  const { manuscript, docs } = canonicalTexts();
+  const regressed = docs.replace('log-bin = mysql-bin', 'log-bin = mysql-bin\nbinlog_format = ROW');
+  assert.throws(
+    () => validateMysqlBinlogTexts(manuscript, regressed),
+    /deprecated MySQL binary log assignment/,
+  );
+});
+
+test('rejects loss of the MariaDB product and version boundary', () => {
+  const { manuscript, docs } = canonicalTexts();
+  const regressed = manuscript.replace('MariaDB 10.6.1以降', 'MariaDB version unspecified');
+  assert.throws(
+    () => validateMysqlBinlogTexts(regressed, docs),
+    /missing required MySQL binary log marker.*MariaDB 10\.6\.1/,
+  );
+});
+
+test('rejects removal of the non-deprecated verification variable', () => {
+  const { manuscript, docs } = canonicalTexts();
+  const regressed = docs.replace(
+    '@@global.binlog_expire_logs_seconds AS retention_seconds',
+    '604800 AS retention_seconds',
+  );
+  assert.throws(
+    () => validateMysqlBinlogTexts(manuscript, regressed),
+    /missing required MySQL binary log marker.*@@global\.binlog_expire_logs_seconds/,
+  );
+});
+
+test('rejects drift between the manuscript and public retention example', () => {
+  const { manuscript, docs } = canonicalTexts();
+  const regressed = docs.replace('例として7日（604800秒）', '例として14日（1209600秒）');
+  assert.throws(
+    () => validateMysqlBinlogTexts(manuscript, regressed),
+    /MySQL 8\.0\.34 binary log section differs/,
+  );
+});


### PR DESCRIPTION
## 概要

付録Cのbinary log設定をOracle MySQL 8.0.34以降の現行契約へ更新し、MariaDBとのproduct/version境界を明示します。

## 変更

- binary log主例をOracle MySQL 8.0.34以降の新規installation baselineとして分離
- deprecatedな`expire_logs_days = 7`を除去し、次へ更新
  - `binlog_expire_logs_auto_purge = ON`
  - `binlog_expire_logs_seconds = 604800`
- MySQL 8.0.34以降でdeprecatedな明示的`binlog-format = ROW`を主例から除去
- MySQL 8.0ではROWがdefaultであること、既存STATEMENT/MIXED環境は互換性評価後にROWへ移行してから明示設定を除去することを記載
- 7日は例示値とし、最大replica lag、運用余裕、PITR / backup policyからretentionを決定する境界を追加
- `log-bin`のstartup/restart境界と、deprecated変数を参照しない確認SQLを追加
- MariaDB 10.6.1以降との変数・default契約の差を明記し、設定の直接流用を禁止
- `manuscript` / `docs`の対象section同期、deprecated assignment、baseline/retention/verification/product境界を検査する契約と6 testsを追加

## スコープ分離

- DB章全面再編、replication architecture、MariaDB全版比較、#149は対象外
- dependency、lockfile、tracked `node_modules`、formatter pin、workflowは変更しない

## 検証

Node.js 24:

- `npm ci --ignore-scripts`
- full / production `npm audit`: 0 vulnerabilities
- `npm test`: 33/33（network contract 6/6、MySQL contract 6/6）
- `npm run lint`: passed
- 追加scriptへのESLint: passed
- `npm run build`: passed（既存Faraday案内のみ）
- `git diff --check`: passed

固定formatter `69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c`:

- Unicode: 0
- internal links: broken 0
- textlint: 0
- layout risk: 0
- markdown structure: 0

built HTMLでOracle MySQL 8.0.34+、auto purge、604800秒、retention境界、MariaDB境界、確認SQLを確認し、旧`expire_logs_days` / `binlog-format` assignmentがないことを確認しました。MySQL公式3 URLとMariaDB公式URLはHTTP 200です。

Closes #148
