### PR TITLE
docs: replace legacy XSS headers with CSP

### DIFF
--- a/docs/appendices/c.md
+++ b/docs/appendices/c.md
@@ -301,7 +301,7 @@ http {
 }
 ```
 
-Nginxの`add_header`は、下位の`server` / `location`に別の`add_header`があると上位設定を通常継承しません。共通headerをincludeへ切り出して各適用scopeで読み込むか、採用versionで継承契約を明示し、`nginx -t`、reload、error responseを含む実responseで確認してください。
+Nginxの`add_header`は、下位の`server` / `location`に別の`add_header`があると上位設定を通常継承しません。共通headerをincludeへ切り出して各適用scopeで読み込むか、下の静的file用`location`のように同じheaderを再設定します。採用versionで継承契約を明示し、`nginx -t`、reload、error responseを含む実responseで確認してください。
 
 - [Nginx: ngx_http_headers_module](https://nginx.org/en/docs/http/ngx_http_headers_module.html)
 
@@ -341,7 +341,11 @@ server {
     # 静的ファイルのキャッシュ
     location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
         expires 1y;
-        add_header Cache-Control "public, immutable";
+        add_header Cache-Control "public, immutable" always;
+        # このscopeのadd_headerが上位設定を置換するため、共通security headerも再設定する
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" always;
     }
 }
 ```

--- a/docs/appendices/c.md
+++ b/docs/appendices/c.md
@@ -181,6 +181,13 @@ Listen 443
 ServerTokens Prod
 ServerSignature Off
 
+# mod_headersを有効にし、成功・error responseの両方へ適用する
+<IfModule mod_headers.c>
+    Header always set X-Frame-Options "DENY"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'"
+</IfModule>
+
 # MPM設定（preforkモジュール）
 <IfModule mpm_prefork_module>
     StartServers         8
@@ -205,10 +212,6 @@ LogLevel warn
     ErrorLog logs/example_error.log
     CustomLog logs/example_access.log combined
     
-    # セキュリティヘッダー
-    Header always set X-Frame-Options DENY
-    Header always set X-Content-Type-Options nosniff
-    Header always set X-XSS-Protection "1; mode=block"
 </VirtualHost>
 
 # SSL設定
@@ -227,6 +230,25 @@ LogLevel warn
     SSLHonorCipherOrder on
 </VirtualHost>
 ```
+
+`X-XSS-Protection`はnon-standardかつdeprecatedで、legacy browserのfilterが安全なpageへXSSを作り込む場合もあるため、現行hardening例では送信しません。CSPをXSSのdefense-in-depthとして使いますが、context-awareなoutput encoding、untrusted HTMLのsanitization、safe DOM API、input validationを置き換えるものではありません。
+
+上のenforced baselineはsame-origin resourceだけを許可し、inline script/styleと`eval()`系APIを許可しません。既存siteへ直接適用すると機能を壊し得るため、最初に同じpolicyを`Content-Security-Policy-Report-Only`で配信し、実在する収集先を`Reporting-Endpoints`と`report-to`で指定して違反を観測します。必要なinline codeは`'unsafe-inline'`や`'unsafe-eval'`で緩和せず、responseごとのnonce、content hash、または外部fileへ移行してから`Content-Security-Policy`をenforceしてください。
+
+`mod_headers`を有効化したうえで、構文、段階reload、実responseを確認します。
+
+```bash
+sudo apachectl configtest
+sudo systemctl reload httpd
+curl -sSI https://example.com/ | grep -iE '^(content-security-policy|x-content-type-options|x-frame-options):'
+```
+
+公式情報（2026-07-21 JST確認）:
+
+- [MDN: X-XSS-Protection](https://developer.mozilla.org/ja/docs/Web/HTTP/Reference/Headers/X-XSS-Protection)
+- [MDN: Content Security Policy guide](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP)
+- [MDN: Content-Security-Policy-Report-Only](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy-Report-Only)
+- [Apache HTTP Server 2.4: mod_headers](https://httpd.apache.org/docs/2.4/mod/mod_headers.html)
 
 ### Nginx
 
@@ -265,9 +287,9 @@ http {
     
     # セキュリティ設定
     server_tokens off;
-    add_header X-Frame-Options DENY;
-    add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" always;
     
     # Gzip圧縮
     gzip on;
@@ -278,6 +300,10 @@ http {
     include /etc/nginx/conf.d/*.conf;
 }
 ```
+
+Nginxの`add_header`は、下位の`server` / `location`に別の`add_header`があると上位設定を通常継承しません。共通headerをincludeへ切り出して各適用scopeで読み込むか、採用versionで継承契約を明示し、`nginx -t`、reload、error responseを含む実responseで確認してください。
+
+- [Nginx: ngx_http_headers_module](https://nginx.org/en/docs/http/ngx_http_headers_module.html)
 
 #### /etc/nginx/conf.d/example.conf
 ```nginx

--- a/manuscript/appendices/c.md
+++ b/manuscript/appendices/c.md
@@ -280,7 +280,7 @@ http {
 }
 ```
 
-Nginxの`add_header`は、下位の`server` / `location`に別の`add_header`があると上位設定を通常継承しません。共通headerをincludeへ切り出して各適用scopeで読み込むか、採用versionで継承契約を明示し、`nginx -t`、reload、error responseを含む実responseで確認してください。
+Nginxの`add_header`は、下位の`server` / `location`に別の`add_header`があると上位設定を通常継承しません。共通headerをincludeへ切り出して各適用scopeで読み込むか、下の静的file用`location`のように同じheaderを再設定します。採用versionで継承契約を明示し、`nginx -t`、reload、error responseを含む実responseで確認してください。
 
 - [Nginx: ngx_http_headers_module](https://nginx.org/en/docs/http/ngx_http_headers_module.html)
 
@@ -320,7 +320,11 @@ server {
     # 静的ファイルのキャッシュ
     location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
         expires 1y;
-        add_header Cache-Control "public, immutable";
+        add_header Cache-Control "public, immutable" always;
+        # このscopeのadd_headerが上位設定を置換するため、共通security headerも再設定する
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" always;
     }
 }
 ```

--- a/manuscript/appendices/c.md
+++ b/manuscript/appendices/c.md
@@ -163,6 +163,13 @@ Listen 443
 ServerTokens Prod
 ServerSignature Off
 
+# mod_headersを有効にし、成功・error responseの両方へ適用する
+<IfModule mod_headers.c>
+    Header always set X-Frame-Options "DENY"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'"
+</IfModule>
+
 # MPM設定（preforkモジュール）
 <IfModule mpm_prefork_module>
     StartServers         8
@@ -187,10 +194,6 @@ LogLevel warn
     ErrorLog logs/example_error.log
     CustomLog logs/example_access.log combined
     
-    # セキュリティヘッダー
-    Header always set X-Frame-Options DENY
-    Header always set X-Content-Type-Options nosniff
-    Header always set X-XSS-Protection "1; mode=block"
 </VirtualHost>
 
 # SSL設定
@@ -209,6 +212,25 @@ LogLevel warn
     SSLHonorCipherOrder on
 </VirtualHost>
 ```
+
+`X-XSS-Protection`はnon-standardかつdeprecatedで、legacy browserのfilterが安全なpageへXSSを作り込む場合もあるため、現行hardening例では送信しません。CSPをXSSのdefense-in-depthとして使いますが、context-awareなoutput encoding、untrusted HTMLのsanitization、safe DOM API、input validationを置き換えるものではありません。
+
+上のenforced baselineはsame-origin resourceだけを許可し、inline script/styleと`eval()`系APIを許可しません。既存siteへ直接適用すると機能を壊し得るため、最初に同じpolicyを`Content-Security-Policy-Report-Only`で配信し、実在する収集先を`Reporting-Endpoints`と`report-to`で指定して違反を観測します。必要なinline codeは`'unsafe-inline'`や`'unsafe-eval'`で緩和せず、responseごとのnonce、content hash、または外部fileへ移行してから`Content-Security-Policy`をenforceしてください。
+
+`mod_headers`を有効化したうえで、構文、段階reload、実responseを確認します。
+
+```bash
+sudo apachectl configtest
+sudo systemctl reload httpd
+curl -sSI https://example.com/ | grep -iE '^(content-security-policy|x-content-type-options|x-frame-options):'
+```
+
+公式情報（2026-07-21 JST確認）:
+
+- [MDN: X-XSS-Protection](https://developer.mozilla.org/ja/docs/Web/HTTP/Reference/Headers/X-XSS-Protection)
+- [MDN: Content Security Policy guide](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP)
+- [MDN: Content-Security-Policy-Report-Only](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy-Report-Only)
+- [Apache HTTP Server 2.4: mod_headers](https://httpd.apache.org/docs/2.4/mod/mod_headers.html)
 
 ### Nginx
 
@@ -244,9 +266,9 @@ http {
     
     # セキュリティ設定
     server_tokens off;
-    add_header X-Frame-Options DENY;
-    add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" always;
     
     # Gzip圧縮
     gzip on;
@@ -257,6 +279,10 @@ http {
     include /etc/nginx/conf.d/*.conf;
 }
 ```
+
+Nginxの`add_header`は、下位の`server` / `location`に別の`add_header`があると上位設定を通常継承しません。共通headerをincludeへ切り出して各適用scopeで読み込むか、採用versionで継承契約を明示し、`nginx -t`、reload、error responseを含む実responseで確認してください。
+
+- [Nginx: ngx_http_headers_module](https://nginx.org/en/docs/http/ngx_http_headers_module.html)
 
 #### /etc/nginx/conf.d/example.conf
 ```nginx

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
-    "test": "npm run check:metadata && npm run test:network-config && npm run test:mysql-binlog && node --test tests/BookGenerator.test.js tests/ConfigValidator.test.js",
+    "test": "npm run check:metadata && npm run test:network-config && npm run test:mysql-binlog && npm run test:web-security && node --test tests/BookGenerator.test.js tests/ConfigValidator.test.js",
     "format": "prettier --write .",
     "lint": "eslint src/ tests/",
     "build": "cd docs && bundle exec jekyll build",
@@ -23,7 +23,9 @@
     "check:network-config": "node scripts/check-network-config-modernization.js",
     "test:network-config": "node --test scripts/check-network-config-modernization.test.js",
     "check:mysql-binlog": "node scripts/check-mysql-binlog-modernization.js",
-    "test:mysql-binlog": "node --test scripts/check-mysql-binlog-modernization.test.js"
+    "test:mysql-binlog": "node --test scripts/check-mysql-binlog-modernization.test.js",
+    "check:web-security": "node scripts/check-web-security-headers.js",
+    "test:web-security": "node --test scripts/check-web-security-headers.test.js"
   },
   "keywords": [
     "book",

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -6,6 +6,7 @@ import util from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { validateNetworkConfigModernization } from './check-network-config-modernization.js';
 import { validateMysqlBinlogModernization } from './check-mysql-binlog-modernization.js';
+import { validateWebSecurityHeaders } from './check-web-security-headers.js';
 
 const REPO_SLUG = 'IT-infra-troubleshooting-book';
 const GITHUB_URL = `https://github.com/itdojp/${REPO_SLUG}`;
@@ -394,6 +395,12 @@ try {
 
 try {
   validateMysqlBinlogModernization(root);
+} catch (error) {
+  errors.push(error instanceof Error ? error.message : String(error));
+}
+
+try {
+  validateWebSecurityHeaders(root);
 } catch (error) {
   errors.push(error instanceof Error ? error.message : String(error));
 }

--- a/scripts/check-web-security-headers.js
+++ b/scripts/check-web-security-headers.js
@@ -19,7 +19,7 @@ const sections = [
   {
     name: 'Nginx CSP procedure',
     start: '#### /etc/nginx/nginx.conf',
-    end: '#### /etc/nginx/conf.d/example.conf',
+    end: '## データベース設定例',
   },
 ];
 
@@ -48,6 +48,7 @@ const nginxMarkers = [
   'add_header Content-Security-Policy',
   'form-action \'self\'" always;',
   '下位の`server` / `location`に別の`add_header`があると上位設定を通常継承しません',
+  'このscopeのadd_headerが上位設定を置換するため、共通security headerも再設定する',
   '`nginx -t`',
   'https://nginx.org/en/docs/http/ngx_http_headers_module.html',
 ];
@@ -112,6 +113,11 @@ export function validateWebSecurityHeaderTexts(manuscript, docs) {
     const nginx = extractSection(text, sections[1], label);
     requireMarkers(apache, apacheMarkers, `${label} Apache CSP section`);
     requireMarkers(nginx, nginxMarkers, `${label} Nginx CSP section`);
+    if (nginx.split('add_header Content-Security-Policy').length - 1 < 2) {
+      throw new WebSecurityHeaderContractError(
+        `${label} Nginx CSP section must repeat the enforced policy in the static-assets location`,
+      );
+    }
     extracted[label] = { apache, nginx };
   }
 

--- a/scripts/check-web-security-headers.js
+++ b/scripts/check-web-security-headers.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export class WebSecurityHeaderContractError extends Error {}
+
+const appendixPaths = {
+  manuscript: 'manuscript/appendices/c.md',
+  docs: 'docs/appendices/c.md',
+};
+
+const sections = [
+  {
+    name: 'Apache CSP procedure',
+    start: '#### /etc/httpd/conf/httpd.conf (基本設定)',
+    end: '### Nginx',
+  },
+  {
+    name: 'Nginx CSP procedure',
+    start: '#### /etc/nginx/nginx.conf',
+    end: '#### /etc/nginx/conf.d/example.conf',
+  },
+];
+
+const apacheMarkers = [
+  '<IfModule mod_headers.c>',
+  'Header always set Content-Security-Policy',
+  "default-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'",
+  '`X-XSS-Protection`はnon-standardかつdeprecated',
+  'CSPをXSSのdefense-in-depth',
+  'context-awareなoutput encoding',
+  'untrusted HTMLのsanitization',
+  'Content-Security-Policy-Report-Only',
+  'Reporting-Endpoints',
+  '`report-to`',
+  "`'unsafe-inline'`や`'unsafe-eval'`で緩和せず",
+  'responseごとのnonce',
+  'content hash',
+  'sudo apachectl configtest',
+  'https://developer.mozilla.org/ja/docs/Web/HTTP/Reference/Headers/X-XSS-Protection',
+  'https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP',
+  'https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy-Report-Only',
+  'https://httpd.apache.org/docs/2.4/mod/mod_headers.html',
+];
+
+const nginxMarkers = [
+  'add_header Content-Security-Policy',
+  'form-action \'self\'" always;',
+  '下位の`server` / `location`に別の`add_header`があると上位設定を通常継承しません',
+  '`nginx -t`',
+  'https://nginx.org/en/docs/http/ngx_http_headers_module.html',
+];
+
+const forbiddenDirectivePatterns = [
+  {
+    pattern: /^\s*Header\s+(?:always\s+)?set\s+X-XSS-Protection\b/im,
+    message: 'Apache must not enable the deprecated X-XSS-Protection header',
+  },
+  {
+    pattern: /^\s*add_header\s+X-XSS-Protection\b/im,
+    message: 'Nginx must not enable the deprecated X-XSS-Protection header',
+  },
+  {
+    pattern: /^\s*(?:Header\s+(?:always\s+)?set|add_header)\s+Content-Security-Policy[^\n]*(?:'unsafe-inline'|'unsafe-eval')/im,
+    message: 'the enforced CSP example must not contain unsafe-inline or unsafe-eval',
+  },
+];
+
+function readRequired(root, relativePath) {
+  try {
+    return fs.readFileSync(path.join(root, relativePath), 'utf8');
+  } catch (error) {
+    throw new WebSecurityHeaderContractError(
+      `web security header contract could not read ${relativePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function extractSection(text, section, label) {
+  const start = text.indexOf(section.start);
+  if (start < 0) {
+    throw new WebSecurityHeaderContractError(`${label} is missing ${section.name} start marker`);
+  }
+  const end = text.indexOf(section.end, start + section.start.length);
+  if (end < 0) {
+    throw new WebSecurityHeaderContractError(`${label} is missing ${section.name} end marker`);
+  }
+  return text.slice(start, end).trim();
+}
+
+function requireMarkers(text, markers, label) {
+  for (const marker of markers) {
+    if (!text.includes(marker)) {
+      throw new WebSecurityHeaderContractError(
+        `${label} is missing required web security marker ${JSON.stringify(marker)}`,
+      );
+    }
+  }
+}
+
+export function validateWebSecurityHeaderTexts(manuscript, docs) {
+  const extracted = {};
+  for (const [label, text] of Object.entries({ manuscript, docs })) {
+    for (const { pattern, message } of forbiddenDirectivePatterns) {
+      if (pattern.test(text)) {
+        throw new WebSecurityHeaderContractError(`${label} appendix C: ${message}`);
+      }
+    }
+
+    const apache = extractSection(text, sections[0], label);
+    const nginx = extractSection(text, sections[1], label);
+    requireMarkers(apache, apacheMarkers, `${label} Apache CSP section`);
+    requireMarkers(nginx, nginxMarkers, `${label} Nginx CSP section`);
+    extracted[label] = { apache, nginx };
+  }
+
+  for (const { name } of sections) {
+    const key = name.startsWith('Apache') ? 'apache' : 'nginx';
+    if (extracted.manuscript[key] !== extracted.docs[key]) {
+      throw new WebSecurityHeaderContractError(
+        `${name} differs between manuscript/appendices/c.md and docs/appendices/c.md`,
+      );
+    }
+  }
+
+  return { synchronizedSectionCount: sections.length };
+}
+
+export function validateWebSecurityHeaders(
+  root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'),
+) {
+  return validateWebSecurityHeaderTexts(
+    readRequired(root, appendixPaths.manuscript),
+    readRequired(root, appendixPaths.docs),
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const result = validateWebSecurityHeaders();
+    console.log(
+      `OK: deprecated XSS filter headers are absent and CSP procedures are synchronized (${result.synchronizedSectionCount} sections)`,
+    );
+  } catch (error) {
+    console.error(`ERROR: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}

--- a/scripts/check-web-security-headers.test.js
+++ b/scripts/check-web-security-headers.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { validateWebSecurityHeaderTexts } from './check-web-security-headers.js';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function canonicalTexts() {
+  return {
+    manuscript: fs.readFileSync(path.join(root, 'manuscript/appendices/c.md'), 'utf8'),
+    docs: fs.readFileSync(path.join(root, 'docs/appendices/c.md'), 'utf8'),
+  };
+}
+
+test('accepts synchronized Apache and Nginx CSP procedures', () => {
+  const { manuscript, docs } = canonicalTexts();
+  assert.deepEqual(validateWebSecurityHeaderTexts(manuscript, docs), { synchronizedSectionCount: 2 });
+  assert.deepEqual(
+    validateWebSecurityHeaderTexts(manuscript.replaceAll('\n', '\r\n'), docs.replaceAll('\n', '\r\n')),
+    { synchronizedSectionCount: 2 },
+  );
+});
+
+test('rejects X-XSS-Protection directives for Apache or Nginx', () => {
+  const { manuscript, docs } = canonicalTexts();
+  for (const regressed of [
+    manuscript.replace(
+      'Header always set X-Content-Type-Options "nosniff"',
+      'Header always set X-XSS-Protection "1; mode=block"',
+    ),
+    manuscript.replace(
+      'add_header X-Content-Type-Options "nosniff" always;',
+      'add_header X-XSS-Protection "1; mode=block";',
+    ),
+  ]) {
+    assert.throws(
+      () => validateWebSecurityHeaderTexts(regressed, docs),
+      /must not enable the deprecated X-XSS-Protection header/,
+    );
+  }
+});
+
+test('rejects unsafe-inline or unsafe-eval in an enforced CSP directive', () => {
+  const { manuscript, docs } = canonicalTexts();
+  for (const keyword of ["'unsafe-inline'", "'unsafe-eval'"]) {
+    const regressed = docs.replace("script-src 'self'", `script-src 'self' ${keyword}`);
+    assert.throws(
+      () => validateWebSecurityHeaderTexts(manuscript, regressed),
+      /enforced CSP example must not contain unsafe-inline or unsafe-eval/,
+    );
+  }
+});
+
+test('requires Report-Only rollout guidance inside the Apache section', () => {
+  const { manuscript, docs } = canonicalTexts();
+  const marker = 'Content-Security-Policy-Report-Only';
+  const regressed = `${manuscript.replaceAll(marker, 'CSP report-only marker missing')}\n\n${marker}\n`;
+  assert.throws(
+    () => validateWebSecurityHeaderTexts(regressed, docs),
+    /Apache CSP section is missing required web security marker.*Content-Security-Policy-Report-Only/,
+  );
+});
+
+test('requires an enforced CSP in the Nginx example', () => {
+  const { manuscript, docs } = canonicalTexts();
+  const regressed = docs.replace('add_header Content-Security-Policy', 'add_header X-Policy-Placeholder');
+  assert.throws(
+    () => validateWebSecurityHeaderTexts(manuscript, regressed),
+    /Nginx CSP section is missing required web security marker.*add_header Content-Security-Policy/,
+  );
+});
+
+test('rejects drift between the manuscript and public Apache policy', () => {
+  const { manuscript, docs } = canonicalTexts();
+  const regressed = docs.replace('sudo systemctl reload httpd', 'sudo systemctl restart httpd');
+  assert.throws(
+    () => validateWebSecurityHeaderTexts(manuscript, regressed),
+    /Apache CSP procedure differs/,
+  );
+});

--- a/scripts/check-web-security-headers.test.js
+++ b/scripts/check-web-security-headers.test.js
@@ -66,10 +66,23 @@ test('requires Report-Only rollout guidance inside the Apache section', () => {
 
 test('requires an enforced CSP in the Nginx example', () => {
   const { manuscript, docs } = canonicalTexts();
-  const regressed = docs.replace('add_header Content-Security-Policy', 'add_header X-Policy-Placeholder');
+  const regressed = docs.replaceAll('add_header Content-Security-Policy', 'add_header X-Policy-Placeholder');
   assert.throws(
     () => validateWebSecurityHeaderTexts(manuscript, regressed),
     /Nginx CSP section is missing required web security marker.*add_header Content-Security-Policy/,
+  );
+});
+
+test('requires security headers in the static-assets location that overrides add_header inheritance', () => {
+  const { manuscript, docs } = canonicalTexts();
+  const marker = 'add_header Content-Security-Policy';
+  const first = docs.indexOf(marker);
+  const second = docs.indexOf(marker, first + marker.length);
+  assert.ok(second > first, 'canonical docs must contain a static-assets CSP directive');
+  const regressed = `${docs.slice(0, second)}# static-assets CSP missing${docs.slice(second + marker.length)}`;
+  assert.throws(
+    () => validateWebSecurityHeaderTexts(manuscript, regressed),
+    /must repeat the enforced policy in the static-assets location/,
   );
 });
 


### PR DESCRIPTION
## 概要

Apache/Nginxのhardening例からdeprecatedな`X-XSS-Protection` directiveを除去し、CSPを現行のXSS defense-in-depthへ接続します。

## 変更

- ApacheとNginxの主例から`X-XSS-Protection: 1; mode=block`を全件除去
- Apache 2.4 `mod_headers`へ、non-2xxを含めて適用するenforced CSP baselineを追加
- Nginxへ同一policyを`always`付きで追加
- policyは次を満たす
  - same-origin baseline
  - `object-src 'none'`
  - `base-uri 'self'`
  - `frame-ancestors 'none'`
  - `form-action 'self'`
  - enforced directiveに`unsafe-inline` / `unsafe-eval`なし
- CSPはoutput encoding、sanitization、safe DOM API、input validationを置換しない責務境界を明示
- 既存siteでは、実在する`Reporting-Endpoints` + `report-to`を用意したReport-Onlyで観測し、nonce/hash/外部fileへ移行してからenforceする段階導入を追加
- Apache `configtest` / reload / response確認を追加
- Nginx `add_header`のscope継承境界、`nginx -t` / reload / response確認を追加
- source/docsのApache・Nginx 2 section同期、legacy directive、unsafe keyword、CSP/rollout/responsibility markerを検査する契約と6 testsを追加

## スコープ分離

- deterministic auditでNginx主例にも同じlegacy headerを検出したため、book内に誤ったhardeningを残さない最小semantic scopeとして同時に除去
- Apache hardening全面再設計、application側XSS対策実装、report collector構築は対象外
- dependency、lockfile、tracked `node_modules`、formatter pin、workflowは変更しない

## 検証

Node.js 24:

- `npm ci --ignore-scripts`
- full / production `npm audit`: 0 vulnerabilities
- `npm test`: 33/33、network/MySQL/web-security contract各6/6
- `npm run lint`: passed
- 追加scriptへのESLint: passed
- `npm run build`: passed（既存Faraday案内のみ）
- `git diff --check`: passed

固定formatter `69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c`:

- Unicode: 0
- internal links: broken 0
- textlint: 0
- layout risk: 0
- markdown structure: 0

built HTMLでApache/Nginx CSP、Report-Only/Reporting-Endpoints、nonce/hash、責務境界、Nginx継承注意を確認し、Apache/Nginxの`X-XSS-Protection` directiveが0件であることを確認しました。MDN 3 URL、Apache/Nginx公式URLはHTTP 200です。

Closes #149
